### PR TITLE
fix: handle empty $e->return in renderHtmxResponse

### DIFF
--- a/FormBuilderHtmx.module.php
+++ b/FormBuilderHtmx.module.php
@@ -71,8 +71,9 @@ class FormBuilderHtmx extends Wire implements Module {
   {
     $this->wire->addHookAfter(
       'Page::render',
-      fn ($e) => !empty($e->return) && ( 
-	      $this->isHtmxRequest() && $e->return = $this->renderHtmxResponse($e->return)
+      fn ($e) =>  $this->isHtmxRequest() && ( 
+        !empty($e->return) && $e->return = $this->renderHtmxResponse($e->return)
+      )
     );
   }
 

--- a/FormBuilderHtmx.module.php
+++ b/FormBuilderHtmx.module.php
@@ -71,7 +71,8 @@ class FormBuilderHtmx extends Wire implements Module {
   {
     $this->wire->addHookAfter(
       'Page::render',
-      fn ($e) => $this->isHtmxRequest() && $e->return = $this->renderHtmxResponse($e->return)
+      fn ($e) => !empty($e->return) && ( 
+	      $this->isHtmxRequest() && $e->return = $this->renderHtmxResponse($e->return)
     );
   }
 
@@ -172,6 +173,6 @@ class FormBuilderHtmx extends Wire implements Module {
 
     preg_match($pattern, $renderedPageMarkup, $matches);
 
-    return $matches[0];
+    return $matches[0] ?? '';
   }
 }


### PR DESCRIPTION
- Added a check to ensure $e->return is not empty before processing.
- Modified renderHtmxResponse to return an empty string if no matches are found, preventing null values.